### PR TITLE
fix: sync react version with galoy-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "graphql": "^16.2.0",
     "html5-qrcode": "^2.1.6",
     "intl-tel-input": "^17.0.15",
-    "react": "^18.0.0-rc.0-next-529dc3ce8-20220124",
-    "react-dom": "^18.0.0-rc.0-next-529dc3ce8-20220124",
+    "react": "^18.0.0-rc.0-next-2ed58eb88-20220126",
+    "react-dom": "^18.0.0-rc.0-next-2ed58eb88-20220126",
     "use-debounce": "^7.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3575,7 +3575,7 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-react-dom@^18.0.0-rc.0-next-529dc3ce8-20220124:
+react-dom@^18.0.0-rc.0-next-2ed58eb88-20220126:
   version "18.0.0-rc.0-next-fe905f152-20220107"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-rc.0-next-fe905f152-20220107.tgz#22714f7c6e006e4728f87972df2774818022dcaa"
   integrity sha512-tl+6q+8h9Vj7r4iI1jYQfLp4oHLC+f7tenqlYBw9eOyJ/SXJXzZ0Mp7QG1LYkK+oapO3vlj5I7ddnbnf8bcDJQ==
@@ -3594,7 +3594,7 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react@^18.0.0-rc.0-next-529dc3ce8-20220124:
+react@^18.0.0-rc.0-next-2ed58eb88-20220126:
   version "18.0.0-rc.0-next-fe905f152-20220107"
   resolved "https://registry.yarnpkg.com/react/-/react-18.0.0-rc.0-next-fe905f152-20220107.tgz#0dbc93be2b5ff5df4a353c74bbabfc97e47d8098"
   integrity sha512-eePjzo6pCiwk9iDRYG0Hn5F0p9e7dlLGIys/eeLUCxByHP90rsXg/H/842S6ggBgarcfvRtDu8cAU7kxfLC4MA==


### PR DESCRIPTION
galoy react is not working in combination with galoy-client and web wallet because of differing react versions (see https://github.com/GaloyMoney/galoy-client/blob/main/package.json#L26)